### PR TITLE
3: Arrumar erro de "fav icon" após o deploy no servidor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const app = express()
-const port = 3000
 
 app.get('/', (req, res) => {
   res.send('Hello World!')
@@ -14,6 +13,6 @@ app.get('/noite', (req, res) => {
     res.send('hello noite!')
   })
 
-app.listen(port, () => {
+app.listen(process.env.PORT || 5000, () => {
   console.log(`Example app listening on port ${port}`)
 })


### PR DESCRIPTION
Aparentemente o heroku ja usa uma variavel de ambiente para setar a
porta do servidor atraves do process.env.PORT.